### PR TITLE
RAIN-12333

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <a href="https://www.lacework.com/"><img src="https://www.lacework.com/wp-content/uploads/2019/07/Lacework_Logo_color_2019.svg" width="250px" height="100px" title="Lacework" alt="Lacework"></a>
 
-# Lacework Agent Release
-The source for officially supported Lacework agent releases
+# Lacework Agent Releases
+This site provides the officially supported Lacework agent releases. 
 
 # Lacework Agent Documentation
-Install and configure agent, use the polygraph, and learn about the host dossiers <a href="https://support.lacework.com/hc/en-us/categories/360001044834-Lacework-for-Workload-Security" target="_blank">**here**</a>.
+For information about supported operating systems, how to install and configure the agent, agent features, and Workload dossiers, see <a href="https://support.lacework.com/hc/en-us/categories/360001044834-Lacework-for-Workload-Security" target="_blank">Lacework for Workload Security</a>.
 
-Latest Lacework Documentation are available <a href="https://support.lacework.com/hc/en-us" target="_blank">**here**</a>.
+Under **Releases**, the release page for each agent release contains a direct link to the specific agent release notes. 
+For all the agent release notes, see <a href="https://support.lacework.com/hc/en-us/categories/360000539793-Release-Updates" target="_blank">Release Updates</a>. 
+
+The Lacework Documentation is available <a href="https://support.lacework.com/hc/en-us" target="_blank">**here**</a>.


### PR DESCRIPTION
Here are my suggestions for improvement to the top-level page. 
I changed this sentence "The source for the officially supported Lacework agent releases." because it implies that we are providing the source code to the agents. Plus the fact that this is a GitHub site implies that it is source, also.